### PR TITLE
Interactables Fix

### DIFF
--- a/Assets/Scenes/SandboxScene.unity
+++ b/Assets/Scenes/SandboxScene.unity
@@ -281,6 +281,74 @@ Transform:
   m_Children: []
   m_Father: {fileID: 113523554}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &222714528
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7508131334010841425, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_Name
+      value: Door
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.509153
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0000009536743
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.5047216
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8455302711992743565, guid: bc60a82d631c6a842a636cda46f232ca,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bc60a82d631c6a842a636cda46f232ca, type: 3}
 --- !u!1001 &380038681
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -293,6 +361,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Elevator
+      objectReference: {fileID: 0}
+    - target: {fileID: 6852952478080575646, guid: 2a2e453ba175cbc4c9579c670db15878,
+        type: 3}
+      propertyPath: UseTransform
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8518807652300261211, guid: 2a2e453ba175cbc4c9579c670db15878,
         type: 3}
@@ -400,11 +473,12 @@ MonoBehaviour:
   IconLocalPosition: {x: 0, y: 3, z: 0}
   dialogueBubbleOffset: {x: -2.02, y: 4.17, z: 0}
   npcConversation: {fileID: 4900000, guid: 78fae791d8e25a445ac2b2e5cfc5205f, type: 3}
+  PossibleTrades:
+    trades: []
   BarterResponseMatrix: {fileID: 11400000, guid: 4df41baae4ac8884d9b9ab903aa274e5,
     type: 2}
   BarterNeutralBehaviour: {fileID: 11400000, guid: d5da7a0cc6260ac499f7b5f8e6536442,
     type: 2}
-  PrizeCard: {fileID: 0}
   DecayPerSecond: 5
   WillingnessPerMatch: 5
   WillingnessPerFail: -5
@@ -1825,3 +1899,4 @@ SceneRoots:
   - {fileID: 4120044077144853147}
   - {fileID: 935982093688392437}
   - {fileID: 670184140}
+  - {fileID: 222714528}

--- a/Assets/Scripts/Environment/Interactables/LockedInteractable.cs
+++ b/Assets/Scripts/Environment/Interactables/LockedInteractable.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -10,6 +7,15 @@ public class LockedInteractable : Interactable
     [SerializeField] private bool removeIfItem = false;
     [SerializeField] private bool locked = true;
     [SerializeField] private UnityEvent callbackFunction;
+
+    private Vector3 _iconPositionStorage;
+    private bool _useTransformStorage;
+
+    private void Start()
+    {
+        _iconPositionStorage = IconLocalPosition;
+        _useTransformStorage = UseTransform;
+    }
 
     public override void Interaction()
     {
@@ -31,11 +37,32 @@ public class LockedInteractable : Interactable
 
     public override void Highlight()
     {
+        if (!GameManager.Instance) { return; }
 
+        if (!locked || GameManager.Inventory.HasCard(RequiredCard))
+        {
+            UseTransform = _useTransformStorage;
+            IconLocalPosition = _iconPositionStorage;
+        } else if (locked || !GameManager.Inventory.HasCard(RequiredCard))
+        {
+            UseTransform = false;
+            IconLocalPosition = Vector3.down * 100;
+        }
     }
 
     public override void UnHighlight()
     {
-        
+        if (!GameManager.Instance) { return; }
+
+        if (!locked || GameManager.Inventory.HasCard(RequiredCard))
+        {
+            UseTransform = _useTransformStorage;
+            IconLocalPosition = _iconPositionStorage;
+        }
+        else if (locked || !GameManager.Inventory.HasCard(RequiredCard))
+        {
+            UseTransform = false;
+            IconLocalPosition = Vector3.down * 100;
+        }
     }
 }

--- a/Assets/Scripts/Environment/Interactables/LockedInteractable.cs
+++ b/Assets/Scripts/Environment/Interactables/LockedInteractable.cs
@@ -11,6 +11,9 @@ public class LockedInteractable : Interactable
     private Vector3 _iconPositionStorage;
     private bool _useTransformStorage;
 
+    // Set by other scripts, a force switch to hide the icon
+    [HideInInspector] public bool HideIcon = false;
+
     private void Start()
     {
         _iconPositionStorage = IconLocalPosition;
@@ -22,7 +25,7 @@ public class LockedInteractable : Interactable
         if (GameManager.Inventory.HasCard(RequiredCard))
         {
             locked = false;
-            
+
             if (RequiredCard.Type == GameEnums.CardTypes.ITEM && removeIfItem)
             {
                 GameManager.Inventory.RemoveCard(RequiredCard);
@@ -33,36 +36,43 @@ public class LockedInteractable : Interactable
         {
             callbackFunction.Invoke();
         }
+
+        UpdateInteractIconLocation();
     }
 
     public override void Highlight()
     {
-        if (!GameManager.Instance) { return; }
-
-        if (!locked || GameManager.Inventory.HasCard(RequiredCard))
-        {
-            UseTransform = _useTransformStorage;
-            IconLocalPosition = _iconPositionStorage;
-        } else if (locked || !GameManager.Inventory.HasCard(RequiredCard))
-        {
-            UseTransform = false;
-            IconLocalPosition = Vector3.down * 100;
-        }
+        UpdateInteractIconLocation();
     }
 
     public override void UnHighlight()
     {
+        UpdateInteractIconLocation();
+    }
+
+    private void UpdateInteractIconLocation()
+    {
         if (!GameManager.Instance) { return; }
 
-        if (!locked || GameManager.Inventory.HasCard(RequiredCard))
+        // Show using variables set in inspector, downside is it can't update in runtime
+        if ((!locked || GameManager.Inventory.HasCard(RequiredCard)) && !HideIcon)
         {
             UseTransform = _useTransformStorage;
             IconLocalPosition = _iconPositionStorage;
         }
-        else if (locked || !GameManager.Inventory.HasCard(RequiredCard))
+        // Hide the Icon
+        else if (locked || !GameManager.Inventory.HasCard(RequiredCard) || HideIcon)
         {
+            // Manually hiding it out of bounds
             UseTransform = false;
             IconLocalPosition = Vector3.down * 100;
+
+            // Turning off the icon if it exists in scene (attached to player)
+            InteractionIcon interactionIcon = FindFirstObjectByType<InteractionIcon>();
+            if (interactionIcon != null)
+            {
+                interactionIcon.Hide();
+            }
         }
     }
 }

--- a/Assets/Scripts/Environment/Locked Door/DoorController.cs
+++ b/Assets/Scripts/Environment/Locked Door/DoorController.cs
@@ -10,7 +10,7 @@ public class DoorController : MonoBehaviour
     [SerializeField, BoxGroup("Doors")] private HingeJoint leftDoor;
     [SerializeField, BoxGroup("Doors")] private HingeJoint rightDoor;
 
-
+    [ReadOnly] public bool IsOpen = false;
     #endregion
 
     #region ========== [ PRIVATE PROPERTIES ] ==========
@@ -26,6 +26,14 @@ public class DoorController : MonoBehaviour
     {
         leftDoor.useMotor = true;
         rightDoor.useMotor = true;
+
+        IsOpen = true;
+
+        LockedInteractable lockedInteractable = GetComponent<LockedInteractable>();
+        if (lockedInteractable != null)
+        {
+            lockedInteractable.HideIcon = true;
+        }
     }
 
     #endregion

--- a/Assets/Writing/Tutorial.ink.meta
+++ b/Assets/Writing/Tutorial.ink.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8bef305f7df9d0a44ab35f701b81cc23
+guid: 1067acf31d3308048809a59dd3c91d78
 DefaultImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
Created a system to hide the interaction icon on LockedInteractables if you cannot use it.

Also made it so that the icon is hidden after the locked door is opened

### Files Changed:
LockedInteractable.cs
DoorController.cs
SandboxScene.unity
Tutorial.ink.meta (idk why, but it wanted me to)